### PR TITLE
Name attribute for a node should be required

### DIFF
--- a/src/main/resources/edu/umontreal/hatchery/roslaunch/roslaunch.xsd
+++ b/src/main/resources/edu/umontreal/hatchery/roslaunch/roslaunch.xsd
@@ -131,7 +131,7 @@
             <xs:attribute name='unless' type='StringType'/>
             <xs:attribute name='pkg' type='StringType' use='required'/>
             <xs:attribute name='type' type='StringType' use='required'/>
-            <xs:attribute name='name' type='StringType'/>
+            <xs:attribute name='name' type='StringType' use='required'/>
             <xs:attribute name='args' type='StringType'/>
             <xs:attribute name='machine' type='StringType'/>
             <xs:attribute name='respawn' type="BoolType"/>


### PR DESCRIPTION
A launch file is not valid if the `name` attribute of a `node` tag is missing